### PR TITLE
Updating the Kubernetes Cluster status interface

### DIFF
--- a/src/modules/kubernetes/types/kubernetes-cluster-status.ts
+++ b/src/modules/kubernetes/types/kubernetes-cluster-status.ts
@@ -1,5 +1,5 @@
 export type KubernetesClusterStatus = 'running' | 'provisioning' | 'errored';
 export interface IKubernetesClusterStatus {
-  status: KubernetesClusterStatus | string;
+  state: KubernetesClusterStatus | string;
   message: string;
 }


### PR DESCRIPTION
According to the documentation  at https://developers.digitalocean.com/documentation/v2/#list-all-kubernetes-clusters retrieved Kubernetes clusters status object looks like 
"status": {
  "state": "provisioning",
  "message": "provisioning"
 }
where the child of status is state not status, this causes type errors when using the library to retrieve k8s cluster info.