### PR TITLE
Add retrieve active deployment logs api

### DIFF
--- a/src/app/get-active-deployment-logs/get-active-deployment-logs.mock.ts
+++ b/src/app/get-active-deployment-logs/get-active-deployment-logs.mock.ts
@@ -1,0 +1,20 @@
+export const request = {
+  "headers": {
+    "Content-Type": "application/json",
+  },
+};
+export const response = {
+    "body": {
+      "live_url": "https://logs-example/build.log",
+      "historic_urls": [
+        "https://logs-example/archive/build.log"
+      ]
+    },
+    "headers": {
+      "content-type": "application/json; charset=utf-8",
+      "status": 200,
+      "ratelimit-limit": 1200,
+      "ratelimit-remaining": 1137,
+      "ratelimit-reset": 1415984218
+    },
+};

--- a/src/app/get-active-deployment-logs/get-active-deployment-logs.spec.ts
+++ b/src/app/get-active-deployment-logs/get-active-deployment-logs.spec.ts
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { createContext } from '../../common';
+import { getActiveDeploymentLogs } from './get-active-deployment-logs';
+import * as MOCK from './get-active-deployment-logs.mock';
+
+describe('app', () => {
+  const APP_ID = 'app-id';
+  const COMPONENT_NAME = 'comp-name';
+  const URL = `/apps/${APP_ID}/components/${COMPONENT_NAME}/logs`;
+  const TOKEN = process.env.TEST_TOKEN as string;
+  const mock = new MockAdapter(axios);
+  const params = {
+    pod_connection_timeout: '1m',
+    follow: false,
+    type: 'BUILD',
+  };
+  mock
+    .onGet(URL)
+    .reply(
+      MOCK.response.headers.status,
+      MOCK.response.body,
+      MOCK.response.headers
+    );
+  const context = createContext({
+    axios,
+    token: TOKEN,
+  });
+  beforeEach(() => {
+    mock.resetHistory();
+  });
+  describe('get-active-deployment-logs', () => {
+    it('should be a fn', () => {
+      expect(typeof getActiveDeploymentLogs).toBe('function');
+    });
+    it('should return a fn', () => {
+      expect(typeof getActiveDeploymentLogs(context)).toBe('function');
+    });
+    it('should return a valid response', async () => {
+      const _getActiveDeploymentLogs = getActiveDeploymentLogs(context);
+      const response = await _getActiveDeploymentLogs({
+        app_id: APP_ID,
+        component_name: COMPONENT_NAME,
+      });
+      Object.assign(response, { request: mock.history.get[0] });
+      /// validate response schema
+      expect(typeof response).toBe('object');
+      expect(typeof response.data).toBe('object');
+      expect(typeof response.headers).toBe('object');
+      expect(typeof response.request).toBe('object');
+      expect(typeof response.status).toBe('number');
+      /// validate request
+      const { request } = response;
+      expect(request.baseURL + request.url).toBe(context.endpoint + URL);
+      expect(request.method).toBe('get');
+      expect(request.headers).toMatchObject(MOCK.request.headers);
+      /// validate data
+      expect(response.data).toBeDefined();
+      expect(response.data.live_url).toBeDefined();
+      expect(typeof response.data.live_url).toBe('string');
+      /// validate headers
+      const { headers, status } = response;
+      expect(headers).toMatchObject(MOCK.response.headers);
+      expect(status).toBe(MOCK.response.headers.status);
+    });
+    it('should set query params', async () => {
+      const _getActiveDeploymentLogs = getActiveDeploymentLogs(context);
+      const response = await _getActiveDeploymentLogs({
+        app_id: APP_ID,
+        component_name: COMPONENT_NAME,
+        ...params,
+      });
+      Object.assign(response, { request: mock.history.get[0] });
+      /// validate response schema
+      expect(typeof response).toBe('object');
+      expect(typeof response.data).toBe('object');
+      expect(typeof response.headers).toBe('object');
+      expect(typeof response.request).toBe('object');
+      expect(typeof response.status).toBe('number');
+      /// validate request
+      const { request } = response;
+      expect(request.baseURL + request.url).toBe(context.endpoint + URL);
+      expect(request.method).toBe('get');
+      expect(request.headers).toMatchObject(MOCK.request.headers);
+      expect(request.params).toMatchObject(params);
+      /// validate data
+      expect(response.data).toBeDefined();
+      expect(response.data.live_url).toBeDefined();
+      expect(typeof response.data.live_url).toBe('string');
+    });
+  });
+});

--- a/src/app/get-active-deployment-logs/get-active-deployment-logs.ts
+++ b/src/app/get-active-deployment-logs/get-active-deployment-logs.ts
@@ -14,7 +14,7 @@ export interface IGetActiveDeploymentLogsApiRequest {
   type?: AppDeploymentLogType | string;
 }
 
-export type GetAppDeploymentLogsResponse =
+export type GetActiveDeploymentLogsResponse =
   IResponse<IGetActiveDeploymentLogsApiResponse>;
 
 export const getActiveDeploymentLogs =
@@ -26,7 +26,7 @@ export const getActiveDeploymentLogs =
     pod_connection_timeout,
     type,
   }: IGetActiveDeploymentLogsApiRequest): Promise<
-    Readonly<GetAppDeploymentLogsResponse>
+    Readonly<GetActiveDeploymentLogsResponse>
   > => {
     const path = '/apps';
     const url = `${path}/${app_id}/components/${component_name}/logs`;

--- a/src/app/get-active-deployment-logs/get-active-deployment-logs.ts
+++ b/src/app/get-active-deployment-logs/get-active-deployment-logs.ts
@@ -1,0 +1,38 @@
+import { IResponse, IContext } from '../../types';
+import { AppDeploymentLogType } from '..';
+
+export interface IGetActiveDeploymentLogsApiResponse {
+  historic_urls: string[];
+  live_url: string;
+}
+
+export interface IGetActiveDeploymentLogsApiRequest {
+  app_id: string;
+  component_name: string;
+  follow?: boolean;
+  pod_connection_timeout?: string;
+  type?: AppDeploymentLogType | string;
+}
+
+export type GetAppDeploymentLogsResponse =
+  IResponse<IGetActiveDeploymentLogsApiResponse>;
+
+export const getActiveDeploymentLogs =
+  ({ httpClient }: IContext) =>
+  ({
+    app_id,
+    component_name,
+    follow,
+    pod_connection_timeout,
+    type,
+  }: IGetActiveDeploymentLogsApiRequest): Promise<
+    Readonly<GetAppDeploymentLogsResponse>
+  > => {
+    const path = '/apps';
+    const url = `${path}/${app_id}/components/${component_name}/logs`;
+    const query_params = { follow, pod_connection_timeout, type };
+
+    return httpClient.get<IGetActiveDeploymentLogsApiResponse>(url, {
+      params: query_params,
+    });
+  };

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -2,6 +2,7 @@ export * from './cancel-app-deployment/cancel-app-deployment';
 export * from './create-app-deployment/create-app-deployment';
 export * from './create-app/create-app';
 export * from './delete-app/delete-app';
+export * from './get-active-deployment-logs/get-active-deployment-logs';
 export * from './get-aggregated-app-deployment-logs/get-aggregated-app-deployment-logs';
 export * from './get-app-deployment-logs/get-app-deployment-logs';
 export * from './get-app-deployment/get-app-deployment';


### PR DESCRIPTION
@pjpimentel I add an api to retrieve active deployment logs. Here's the [docs](https://docs.digitalocean.com/reference/api/api-reference/#operation/apps_get_logs_active_deployment)