### PR TITLE
Fix gen-ai/indexing_jobs to use a post body and include data_source_uuids

### DIFF
--- a/src/gen-ai/README.md
+++ b/src/gen-ai/README.md
@@ -473,7 +473,7 @@ try {
 [public docs](https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_create_indexing_job)
 ```javascript
 try {
-  const input = { knowledge_base_uuid: 'uuid' };
+  const input = { knowledge_base_uuid: 'uuid', data_source_uuids: ['ds_uuid'] };
   const { data:{ indexing_job } } = await dots.genAi.createIndexingJob(input);
   console.log(indexing_job);
 } catch (error) {

--- a/src/gen-ai/create-indexing-job/create-indexing-job.spec.ts
+++ b/src/gen-ai/create-indexing-job/create-indexing-job.spec.ts
@@ -1,7 +1,7 @@
 import { createIndexingJob } from './create-indexing-job';
 
 describe('create-indexing-job', () => {
-  const default_input = { knowledge_base_uuid: 'kbid' } as any;
+  const default_input = { knowledge_base_uuid: 'kbid', data_source_uuids: ['ds_uuid'] } as any;
   const default_output = require('crypto').randomBytes(2);
   const httpClient = { post: jest.fn().mockReturnValue(Promise.resolve(default_output)) };
   const context = { httpClient } as any;
@@ -16,9 +16,7 @@ describe('create-indexing-job', () => {
   it('should call axios.post', async () => {
     const _createIndexingJob = createIndexingJob(context);
     await _createIndexingJob(default_input);
-    expect(httpClient.post).toHaveBeenCalledWith(
-      `/gen-ai/knowledge_bases/${default_input.knowledge_base_uuid}/indexing_jobs`
-    );
+    expect(httpClient.post).toHaveBeenCalledWith(`/gen-ai/indexing_jobs`, default_input);
   });
 
   it('should output axios response', async () => {

--- a/src/gen-ai/create-indexing-job/create-indexing-job.ts
+++ b/src/gen-ai/create-indexing-job/create-indexing-job.ts
@@ -7,13 +7,14 @@ export interface ICreateIndexingJobApiResponse {
 
 export interface ICreateIndexingJobApiRequest {
   knowledge_base_uuid: string;
+  data_source_uuids: string[];
 }
 
 export type CreateIndexingJobResponse = IResponse<ICreateIndexingJobApiResponse>;
 
 export const createIndexingJob = ({ httpClient }: IContext) => (
-  { knowledge_base_uuid }: ICreateIndexingJobApiRequest,
+  data: ICreateIndexingJobApiRequest,
 ): Promise<Readonly<CreateIndexingJobResponse>> => {
-  const url = `/gen-ai/knowledge_bases/${knowledge_base_uuid}/indexing_jobs`;
-  return httpClient.post<ICreateIndexingJobApiResponse>(url);
+  const url = `/gen-ai/indexing_jobs`;
+  return httpClient.post<ICreateIndexingJobApiResponse>(url, data);
 }; 


### PR DESCRIPTION
Fix gen-ai/indexing_jobs to use a post body and include data_source_uuids as per https://docs.digitalocean.com/reference/api/digitalocean/#tag/GenAI-Platform-(Public-Preview)/operation/genai_create_indexing_job